### PR TITLE
Add RegisterDial

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -79,16 +79,15 @@ type Dialer interface {
 	DialTimeout(network, address string, timeout time.Duration) (net.Conn, error)
 }
 
-var dials map[string]Dialer
+var dialers map[string]Dialer
 
-// RegisterDial registers a custom dialer. It can then be used by the
+// RegisterDialer registers a custom dialer. It can then be used by the
 // network address mynet(addr), where mynet is the registered new network.
-// addr is passed as a parameter to the dial function.
-func RegisterDial(net string, dial Dialer) {
-	if dials == nil {
-		dials = make(map[string]Dialer)
+func RegisterDialer(net string, dial Dialer) {
+	if dialers == nil {
+		dialers = make(map[string]Dialer)
 	}
-	dials[net] = dial
+	dialers[net] = dial
 }
 
 type defaultDialer struct{}
@@ -96,7 +95,7 @@ type defaultDialer struct{}
 func (d defaultDialer) Dial(ntw, addr string) (net.Conn, error) {
 	// Check if we have a registered Dialer for this network type.
 	// If not, we'll use the default dialer instead.
-	if dial, ok := dials[ntw]; ok {
+	if dial, ok := dialers[ntw]; ok {
 		return dial.Dial(ntw, addr)
 	}
 
@@ -106,7 +105,7 @@ func (d defaultDialer) Dial(ntw, addr string) (net.Conn, error) {
 func (d defaultDialer) DialTimeout(ntw, addr string, timeout time.Duration) (net.Conn, error) {
 	// Check if we have a registered Dialer for this network type.
 	// If not, we'll use the default dialer instead.
-	if dial, ok := dials[ntw]; ok {
+	if dial, ok := dialers[ntw]; ok {
 		return dial.DialTimeout(ntw, addr, timeout)
 	}
 

--- a/conn.go
+++ b/conn.go
@@ -95,7 +95,7 @@ type defaultDialer struct{}
 
 func (d defaultDialer) Dial(ntw, addr string) (net.Conn, error) {
 	// Check if we have a registered Dialer for this network type.
-	// If not, we'll ue the default dialer instead.
+	// If not, we'll use the default dialer instead.
 	if dial, ok := dials[ntw]; ok {
 		return dial.Dial(ntw, addr)
 	}
@@ -105,7 +105,7 @@ func (d defaultDialer) Dial(ntw, addr string) (net.Conn, error) {
 
 func (d defaultDialer) DialTimeout(ntw, addr string, timeout time.Duration) (net.Conn, error) {
 	// Check if we have a registered Dialer for this network type.
-	// If not, we'll ue the default dialer instead.
+	// If not, we'll use the default dialer instead.
 	if dial, ok := dials[ntw]; ok {
 		return dial.DialTimeout(ntw, addr, timeout)
 	}

--- a/conn.go
+++ b/conn.go
@@ -74,33 +74,42 @@ func (s transactionStatus) String() string {
 	panic("not reached")
 }
 
-// DialFunc is a function which can be used to establish the network connection.
-// Custom dial functions must be registered with RegisterDial
-type DialFunc func(addr string) (net.Conn, error)
-
-var dials map[string]DialFunc
-
-// RegisterDial registers a custom dial function. It can then be used by the
-// network address mynet(addr), where mynet is the registered new network.
-// addr is passed as a parameter to the dial function.
-func RegisterDial(net string, dial DialFunc) {
-	if dials == nil {
-		dials = make(map[string]DialFunc)
-	}
-	dials[net] = dial
-}
-
 type Dialer interface {
 	Dial(network, address string) (net.Conn, error)
 	DialTimeout(network, address string, timeout time.Duration) (net.Conn, error)
 }
 
+var dials map[string]Dialer
+
+// RegisterDial registers a custom dialer. It can then be used by the
+// network address mynet(addr), where mynet is the registered new network.
+// addr is passed as a parameter to the dial function.
+func RegisterDial(net string, dial Dialer) {
+	if dials == nil {
+		dials = make(map[string]Dialer)
+	}
+	dials[net] = dial
+}
+
 type defaultDialer struct{}
 
 func (d defaultDialer) Dial(ntw, addr string) (net.Conn, error) {
+	// Check if we have a registered Dialer for this network type.
+	// If not, we'll ue the default dialer instead.
+	if dial, ok := dials[ntw]; ok {
+		return dial.Dial(ntw, addr)
+	}
+
 	return net.Dial(ntw, addr)
 }
+
 func (d defaultDialer) DialTimeout(ntw, addr string, timeout time.Duration) (net.Conn, error) {
+	// Check if we have a registered Dialer for this network type.
+	// If not, we'll ue the default dialer instead.
+	if dial, ok := dials[ntw]; ok {
+		return dial.DialTimeout(ntw, addr, timeout)
+	}
+
 	return net.DialTimeout(ntw, addr, timeout)
 }
 
@@ -233,35 +242,28 @@ func DialOpen(d Dialer, name string) (_ driver.Conn, err error) {
 func dial(d Dialer, o values) (net.Conn, error) {
 	ntw, addr := network(o)
 
-	// Check if we have a registered Dialer for this network type.
-	// If not, we'll ue the default dialer that was passed to us instead.
-	if dial, ok := dials[ntw]; ok {
-		return dial(addr)
-	} else {
-		timeout := o.Get("connect_timeout")
+	timeout := o.Get("connect_timeout")
 
-		// Zero or not specified means wait indefinitely.
-		if timeout != "" && timeout != "0" {
-			seconds, err := strconv.ParseInt(timeout, 10, 0)
-			if err != nil {
-				return nil, fmt.Errorf("invalid value for parameter connect_timeout: %s", err)
-			}
-			duration := time.Duration(seconds) * time.Second
-			// connect_timeout should apply to the entire connection establishment
-			// procedure, so we both use a timeout for the TCP connection
-			// establishment and set a deadline for doing the initial handshake.
-			// The deadline is then reset after startup() is done.
-			deadline := time.Now().Add(duration)
-			conn, err := d.DialTimeout(ntw, addr, duration)
-			if err != nil {
-				return nil, err
-			}
-			err = conn.SetDeadline(deadline)
-			return conn, err
+	// Zero or not specified means wait indefinitely.
+	if timeout != "" && timeout != "0" {
+		seconds, err := strconv.ParseInt(timeout, 10, 0)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for parameter connect_timeout: %s", err)
 		}
-
-		return d.Dial(ntw, addr)
+		duration := time.Duration(seconds) * time.Second
+		// connect_timeout should apply to the entire connection establishment
+		// procedure, so we both use a timeout for the TCP connection
+		// establishment and set a deadline for doing the initial handshake.
+		// The deadline is then reset after startup() is done.
+		deadline := time.Now().Add(duration)
+		conn, err := d.DialTimeout(ntw, addr, duration)
+		if err != nil {
+			return nil, err
+		}
+		err = conn.SetDeadline(deadline)
+		return conn, err
 	}
+	return d.Dial(ntw, addr)
 }
 
 func network(o values) (string, string) {


### PR DESCRIPTION
This adds a function, `RegisterDial` that mirrors the functionality used
in https://github.com/VividCortex/mysql to set a custom dialer to use for
connections to the database. We can use this to set read/write timeouts
on database connections made via TCP.
