### PR TITLE
Rewrite module path to github.com/VividCortex/pq

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/lib/pq
+module github.com/VividCortex/pq
 
 go 1.13


### PR DESCRIPTION
We rewrote all import paths to `github.com/VividCortex/pq` but the module path was left behind.